### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://juantortiz.visualstudio.com/aafdd2b1-12f7-4d28-bb3a-d88dc015b27f/eb8d887b-86f6-463f-8781-f33971affe43/_apis/work/boardbadge/b8d7be81-ee29-4639-94b0-2ab2ae321200)](https://juantortiz.visualstudio.com/aafdd2b1-12f7-4d28-bb3a-d88dc015b27f/_boards/board/t/eb8d887b-86f6-463f-8781-f33971affe43/Microsoft.RequirementCategory)
 # coursedeevops
 AzureCourse


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://juantortiz.visualstudio.com/aafdd2b1-12f7-4d28-bb3a-d88dc015b27f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.